### PR TITLE
new noarch syntax for conda recipes

### DIFF
--- a/stats_arrays/meta.yaml
+++ b/stats_arrays/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch_python: True
+  noarch: python
   number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 


### PR DESCRIPTION
I think we had the exact same issue half a year ago, stats-arrays must somehow have been forgotten. I hope this works now.