### PR TITLE
Use base package for matplotlib, avoid pyqt dependency

### DIFF
--- a/bw2analyzer/meta.yaml
+++ b/bw2analyzer/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   build:
     - bw2calc
     - bw2data
-    - matplotlib
+    - matplotlib-base
     - numpy
     - pyprind
     - stats_arrays
@@ -33,7 +33,7 @@ requirements:
   run:
     - bw2calc
     - bw2data
-    - matplotlib
+    - matplotlib-base
     - numpy
     - pyprind
     - stats_arrays


### PR DESCRIPTION
As noted during the meeting we just had, I think this is all that is required to remove the `pyqt` dependency from the `bw2analyzer` package.

Relevant `conda-forge` matplotlib pull-request: https://github.com/conda-forge/matplotlib-feedstock/pull/178